### PR TITLE
Add issue_id Field to Output of get_issue_comments

### DIFF
--- a/mcp_youtrack/mcp_server.py
+++ b/mcp_youtrack/mcp_server.py
@@ -394,6 +394,7 @@ def get_issue_comments(issue_id: str) -> List[CommentResponse]:
         for comment in comments:
             comment_data = CommentResponse(
                 id=comment.id or "",
+                issue_id=issue_id or "",
                 text=comment.text or "",
                 text_preview=getattr(comment, 'text_preview', None),
                 created=str(comment.created) if comment.created else None,

--- a/mcp_youtrack/mcp_server.py
+++ b/mcp_youtrack/mcp_server.py
@@ -356,6 +356,7 @@ def get_issue_custom_fields(issue_id: str) -> List[CustomFieldResponse]:
 
 
 class CommentResponse(BaseModel):
+    issue_id: str
     id: str
     text: str
     text_preview: Optional[str] = None

--- a/mcp_youtrack/mcp_server.py
+++ b/mcp_youtrack/mcp_server.py
@@ -393,8 +393,8 @@ def get_issue_comments(issue_id: str) -> List[CommentResponse]:
         result = []
         for comment in comments:
             comment_data = CommentResponse(
-                id=comment.id or "",
                 issue_id=issue_id or "",
+                id=comment.id or "",
                 text=comment.text or "",
                 text_preview=getattr(comment, 'text_preview', None),
                 created=str(comment.created) if comment.created else None,


### PR DESCRIPTION
### Description:
This pull request proposes an enhancement to the get_issue_comments function by adding an issue_id field to its output.

### Motivation & Benefits:

**Enhanced Traceability:**
Including issue_id in the output allows us to unambiguously associate each comment with its parent issue. This is particularly useful when processing data for multiple issues or during debugging.

**Improved Integration:**
Downstream processes—such as notification flows, analytics, or further API integrations—often require a reference to the originating issue. By providing issue_id, we simplify data correlation and enable smoother integrations across systems.

**Error Reduction:**
Without issue_id, handling comments from different issues in batch operations can lead to misassociation or processing errors. Adding this field ensures that every comment is clearly tied to its respective issue, thereby reducing potential mistakes.

**Backward Compatibility:**
This change is backward compatible. The new issue_id field is added to the output object without modifying existing data structures or inputs.